### PR TITLE
start_time format for all-day events doesn't include time, so iso_to_datetime() crashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ See http://www.pfspear.net/projects/gcalcron for his first version.
 
 ## Install ##
 
-GcalCron2 requires the `python-gdata` package:
+GcalCron2 depends on a few python libraries:
 
-* Install on Ubuntu, Debian, etc. : `sudo apt-get install python-gdata`
-* Install on Fedora, CentOS, etc. : `sudo yum install python-gdata`
+* Install on Ubuntu, Debian, etc. : `sudo apt-get install python-gdata python-dateutil`
+* Install on Fedora, CentOS, etc. : `sudo yum install python-gdata python-dateutil`
 
 Clone the GcalCron2 repository:
 

--- a/gcalcron2.py
+++ b/gcalcron2.py
@@ -12,6 +12,7 @@ import os
 import stat
 import json
 import datetime
+import dateutil.parser
 import time
 import subprocess
 import re
@@ -119,7 +120,7 @@ class GCalAdapter:
 
     events = []
     for i, event in zip(xrange(len(entries)), entries):
-      event_time = utc_to_local(iso_to_datetime(event.when[0].start_time))
+      event_time = utc_to_local(dateutil.parser.parse(event.when[0].start_time)).replace (tzinfo = None)
       event_id = event.id.text
       if DEBUG: print event_id, '-', event.event_status.value, '-', event.updated.text, ': ', event.title.text, event_time, ' (', event.when[0].start_time, ') ', '=>', event.content.text
       if event.event_status.value == 'CANCELED':
@@ -273,13 +274,6 @@ def local_to_utc(dt):
 
 def utc_to_local(dt):
   return dt - datetime.timedelta(seconds=time.altzone)
-
-def iso_to_datetime(iso):
-  """
-  >>> iso_to_datetime('2011-06-18T12:00:00')
-  datetime.datetime(2011, 6, 18, 12, 0)
-  """
-  return datetime.datetime.strptime(iso[:16], '%Y-%m-%dT%H:%M')
 
 
 def datetime_to_at(dt):


### PR DESCRIPTION
start_time format for all-day events is '%Y-%m-%d', not '%Y-%m-%dT%H:%M'. 

I replaced the `iso_to_datetime()` method with `dateutil.parser.parse()`, which handles both formats seamlessly and defaults the time for all-day events to '00:00'

Here is the error from the crash:

```
Submitting query
Query results received
Traceback (most recent call last):
  File "/home/ndbroadbent/src/python/GCalCron2/gcalcron2.py", line 296, in <module>
    g.sync_gcal_to_cron()
  File "/home/ndbroadbent/src/python/GCalCron2/gcalcron2.py", line 226, in sync_gcal_to_cron
    (events, last_sync) = gcal_adapter.get_events(last_sync, num_days)
  File "/home/ndbroadbent/src/python/GCalCron2/gcalcron2.py", line 122, in get_events
    event_time = utc_to_local(iso_to_datetime(event.when[0].start_time))
  File "/home/ndbroadbent/src/python/GCalCron2/gcalcron2.py", line 276, in iso_to_datetime
    return datetime.datetime.strptime(iso[:16], '%Y-%m-%dT%H:%M')
  File "/usr/lib/python2.6/_strptime.py", line 325, in _strptime
    (data_string, format))
ValueError: time data '2012-01-11' does not match format '%Y-%m-%dT%H:%M'
```
