### PR TITLE
Fixed bug in init() refactor - 'g' needs to be available for g.sync_gcal_to_cron()

### DIFF
--- a/gcalcron2.py
+++ b/gcalcron2.py
@@ -342,6 +342,7 @@ def init():
     g = GCalCron2(load_settings=False)
     g.init_settings(email, password, cal_id)
     g.save_settings()
+    return g
 
 if __name__ == '__main__':
   if '--init' in sys.argv:
@@ -350,7 +351,7 @@ if __name__ == '__main__':
   try:
     g = GCalCron2()
   except IOError:
-    init()
+    g = init()
 
   if '--reset' in sys.argv:
     g.reset_settings()


### PR DESCRIPTION
If `$HOME/.gcalcron2` doesn't exist, and settings are initialized:

Traceback (most recent call last):
  File "./gcalcron2.py", line 353, in <module>
    g.sync_gcal_to_cron()
NameError: name 'g' is not defined
